### PR TITLE
Add load tags error metric

### DIFF
--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/provider/agent/DockerRegistryImageCachingAgent.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/provider/agent/DockerRegistryImageCachingAgent.groovy
@@ -18,6 +18,8 @@ package com.netflix.spinnaker.clouddriver.docker.registry.provider.agent
 
 import com.netflix.spinnaker.cats.agent.*
 import com.netflix.spinnaker.cats.provider.ProviderCache
+import com.netflix.spectator.api.Registry
+import com.netflix.spectator.api.Counter
 import com.netflix.spinnaker.clouddriver.docker.registry.DockerRegistryCloudProvider
 import com.netflix.spinnaker.clouddriver.docker.registry.api.v2.client.DockerRegistryTags
 import com.netflix.spinnaker.clouddriver.docker.registry.cache.DefaultCacheDataBuilder
@@ -47,6 +49,7 @@ class DockerRegistryImageCachingAgent implements CachingAgent, AccountAware, Age
   private final int threadCount
   private final long interval
   private String registry
+  private Counter loadTagsErrorCounter
 
   DockerRegistryImageCachingAgent(DockerRegistryCloudProvider dockerRegistryCloudProvider,
                                   String accountName,
@@ -54,7 +57,8 @@ class DockerRegistryImageCachingAgent implements CachingAgent, AccountAware, Age
                                   int index,
                                   int threadCount,
                                   Long intervalSecs,
-                                  String registry) {
+                                  String registry,
+                                  Registry spectatorRegistry) {
     this.dockerRegistryCloudProvider = dockerRegistryCloudProvider
     this.accountName = accountName
     this.credentials = credentials
@@ -62,6 +66,7 @@ class DockerRegistryImageCachingAgent implements CachingAgent, AccountAware, Age
     this.threadCount = threadCount
     this.interval = TimeUnit.SECONDS.toMillis(intervalSecs)
     this.registry = registry
+    this.loadTagsErrorCounter = spectatorRegistry.counter("load.tags.error")
   }
 
   @Override
@@ -100,6 +105,7 @@ class DockerRegistryImageCachingAgent implements CachingAgent, AccountAware, Age
         if (e instanceof RetrofitError && e.response?.status == 404) {
           log.warn("Could not load tags for ${repository} in ${credentials.client.address}, reason: ${e.message}")
         } else {
+          this.loadTagsErrorCounter.increment()
           log.error("Could not load tags for ${repository} in ${credentials.client.address}", e)
         }
 

--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/provider/agent/DockerRegistryImageCachingAgent.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/provider/agent/DockerRegistryImageCachingAgent.groovy
@@ -66,7 +66,7 @@ class DockerRegistryImageCachingAgent implements CachingAgent, AccountAware, Age
     this.threadCount = threadCount
     this.interval = TimeUnit.SECONDS.toMillis(intervalSecs)
     this.registry = registry
-    this.loadTagsErrorCounter = spectatorRegistry.counter("load.tags.error")
+    this.loadTagsErrorCounter = spectatorRegistry.counter("clouddriver.load.tags.error")
   }
 
   @Override
@@ -102,10 +102,11 @@ class DockerRegistryImageCachingAgent implements CachingAgent, AccountAware, Age
       try {
         tags = credentials.client.getTags(repository)
       } catch (Exception e) {
+        this.loadTagsErrorCounter.increment()
+
         if (e instanceof RetrofitError && e.response?.status == 404) {
           log.warn("Could not load tags for ${repository} in ${credentials.client.address}, reason: ${e.message}")
         } else {
-          this.loadTagsErrorCounter.increment()
           log.error("Could not load tags for ${repository} in ${credentials.client.address}", e)
         }
 

--- a/clouddriver-docker/src/main/java/com/netflix/spinnaker/clouddriver/docker/registry/security/DockerRegistryCredentialsLifecycleHandler.java
+++ b/clouddriver-docker/src/main/java/com/netflix/spinnaker/clouddriver/docker/registry/security/DockerRegistryCredentialsLifecycleHandler.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.docker.registry.security;
 
+import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.cats.agent.Agent;
 import com.netflix.spinnaker.clouddriver.docker.registry.DockerRegistryCloudProvider;
 import com.netflix.spinnaker.clouddriver.docker.registry.provider.DockerRegistryProvider;
@@ -35,6 +36,7 @@ public class DockerRegistryCredentialsLifecycleHandler
 
   private final DockerRegistryProvider provider;
   private final DockerRegistryCloudProvider cloudProvider;
+  private final Registry registry;
 
   @Override
   public void credentialsAdded(DockerRegistryNamedAccountCredentials credentials) {
@@ -67,7 +69,8 @@ public class DockerRegistryCredentialsLifecycleHandler
               i,
               credentials.getCacheThreads(),
               credentials.getCacheIntervalSeconds(),
-              credentials.getRegistry()));
+              credentials.getRegistry(),
+              registry));
     }
     return agents;
   }

--- a/clouddriver-kubernetes/clouddriver-kubernetes.gradle
+++ b/clouddriver-kubernetes/clouddriver-kubernetes.gradle
@@ -95,7 +95,6 @@ dependencies {
   testImplementation "org.junit.platform:junit-platform-runner"
   testImplementation "org.mockito:mockito-core"
   testImplementation "org.mockito:mockito-junit-jupiter"
-  testImplementation "org.mockito:mockito-core"
   testImplementation "cglib:cglib-nodep"
   testImplementation "org.objenesis:objenesis"
   testImplementation "org.spockframework:spock-core"


### PR DESCRIPTION
## Notes
* Adds a metric for Docker LoadTags Exceptions are raised

## Testing
Ran locally and incremented at all times, validated metric was emitted and increased

```
# HELP load_tags_error_total
# TYPE load_tags_error_total counter
load_tags_error_total{customerEnvName="production",customerName="armory",lib="aop",libVer="v1.4.1",spinSvc="clouddriver",} 2.0
```
